### PR TITLE
Explicitly add ssl configure flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
 FROM debian:12
-RUN apt-get update && apt-get install -y build-essential curl libsasl2-dev libzstd-dev python3
+RUN apt-get update && apt-get install -y build-essential curl libsasl2-dev libzstd-dev python3 libssl-dev

--- a/build.sh
+++ b/build.sh
@@ -20,9 +20,9 @@ tar -xf "v$VERSION.tar.gz" || error "Decompression failed"
 cd "librdkafka-$VERSION" || error "Failed to enter source directory"
 if [ ! -f "Makefile.config" ]; then
   if [ "$KERNEL" = "Darwin" ]; then
-    ./configure --install-deps --source-deps-only --enable-static --enable-zstd --disable-curl --disable-zlib --enable-gssapi --enable-sasl || error "Failed to configure and compile dependencies"
+    ./configure --install-deps --source-deps-only --enable-static --enable-zstd --disable-curl --disable-zlib --enable-gssapi --enable-sasl --enable-ssl || error "Failed to configure and compile dependencies"
   elif [ "$KERNEL" = "Linux" ]; then
-    ./configure --disable-zstd --disable-curl --disable-zlib --enable-gssapi --enable-sasl || error "Failed to configure and compile dependencies"
+    ./configure --disable-zstd --disable-curl --disable-zlib --enable-gssapi --enable-sasl --enable-ssl || error "Failed to configure and compile dependencies"
   else
     error "Unknown kernel $KERNEL"
   fi


### PR DESCRIPTION
My initial assumption was that —enable-sasl was enough and it would  automatically pull in OpenSSL, but apparently that wasn’t true because  it also needs to enable some ifdefs in the code